### PR TITLE
Java 7 changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.sonar-plugins</groupId>
     <artifactId>parent</artifactId>
-    <version>18</version>
+    <version>19</version>
   </parent>
 
   <groupId>org.codehaus.sonar.sslr</groupId>

--- a/sslr-core/src/main/java/com/sonar/sslr/api/AstNode.java
+++ b/sslr-core/src/main/java/com/sonar/sslr/api/AstNode.java
@@ -20,14 +20,13 @@
 package com.sonar.sslr.api;
 
 import com.google.common.annotations.Beta;
-import com.google.common.collect.Lists;
 import com.sonar.sslr.impl.matcher.RuleDefinition;
 import org.sonar.sslr.ast.AstSelect;
 import org.sonar.sslr.internal.ast.select.AstSelectFactory;
 import org.sonar.sslr.internal.grammar.MutableParsingRule;
 
 import javax.annotation.Nullable;
-
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -69,7 +68,7 @@ public class AstNode {
   public void addChild(AstNode child) {
     if (child != null) {
       if (children.isEmpty()) {
-        children = Lists.newArrayList();
+        children = new ArrayList<>();
       }
       if (child.hasToBeSkippedFromAst()) {
         if (child.hasChildren()) {
@@ -420,7 +419,7 @@ public class AstNode {
    * @since 1.17
    */
   public List<AstNode> getChildren(AstNodeType... nodeTypes) {
-    List<AstNode> result = Lists.newArrayList();
+    List<AstNode> result = new ArrayList<>();
     for (AstNode child : children) {
       for (AstNodeType nodeType : nodeTypes) {
         if (child.type == nodeType) {
@@ -436,7 +435,7 @@ public class AstNode {
    */
   @Deprecated
   public List<AstNode> findChildren(AstNodeType... nodeTypes) {
-    List<AstNode> result = Lists.newArrayList();
+    List<AstNode> result = new ArrayList<>();
     getDescendants(result, nodeTypes);
     return result;
   }
@@ -459,7 +458,7 @@ public class AstNode {
    * @since 1.17
    */
   public List<AstNode> getDescendants(AstNodeType... nodeTypes) {
-    List<AstNode> result = Lists.newArrayList();
+    List<AstNode> result = new ArrayList<>();
     if (hasChildren()) {
       for (AstNode child : children) {
         child.getDescendants(result, nodeTypes);
@@ -624,7 +623,7 @@ public class AstNode {
    * Return all tokens contained in this tree node. Those tokens can be directly or indirectly attached to this node.
    */
   public List<Token> getTokens() {
-    List<Token> tokens = Lists.newArrayList();
+    List<Token> tokens = new ArrayList<>();
     getTokens(tokens);
     return tokens;
   }

--- a/sslr-core/src/main/java/com/sonar/sslr/api/PreprocessorAction.java
+++ b/sslr-core/src/main/java/com/sonar/sslr/api/PreprocessorAction.java
@@ -19,8 +19,6 @@
  */
 package com.sonar.sslr.api;
 
-import com.google.common.collect.Lists;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -98,8 +96,8 @@ public class PreprocessorAction {
     Objects.requireNonNull(tokensToInject, "tokensToInject cannot be null");
 
     this.numberOfConsumedTokens = numberOfConsumedTokens;
-    this.triviaToInject = Collections.unmodifiableList(Lists.newArrayList(triviaToInject));
-    this.tokensToInject = Collections.unmodifiableList(Lists.newArrayList(tokensToInject));
+    this.triviaToInject = Collections.unmodifiableList(new ArrayList<>(triviaToInject));
+    this.tokensToInject = Collections.unmodifiableList(new ArrayList<>(tokensToInject));
   }
 
   public int getNumberOfConsumedTokens() {

--- a/sslr-core/src/main/java/com/sonar/sslr/api/PreprocessorAction.java
+++ b/sslr-core/src/main/java/com/sonar/sslr/api/PreprocessorAction.java
@@ -24,9 +24,9 @@ import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * This class encapsulates the actions to be performed by a preprocessor.
@@ -94,8 +94,8 @@ public class PreprocessorAction {
    */
   public PreprocessorAction(int numberOfConsumedTokens, List<Trivia> triviaToInject, List<Token> tokensToInject) {
     checkArgument(numberOfConsumedTokens >= 0, "numberOfConsumedTokens(%s) must be greater or equal to 0", numberOfConsumedTokens);
-    checkNotNull(triviaToInject, "triviaToInject cannot be null");
-    checkNotNull(tokensToInject, "tokensToInject cannot be null");
+      Objects.requireNonNull(triviaToInject, "triviaToInject cannot be null");
+    Objects.requireNonNull(tokensToInject, "tokensToInject cannot be null");
 
     this.numberOfConsumedTokens = numberOfConsumedTokens;
     this.triviaToInject = Collections.unmodifiableList(Lists.newArrayList(triviaToInject));

--- a/sslr-core/src/main/java/com/sonar/sslr/api/Token.java
+++ b/sslr-core/src/main/java/com/sonar/sslr/api/Token.java
@@ -20,9 +20,9 @@
 package com.sonar.sslr.api;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -230,7 +230,7 @@ public class Token {
     public Builder setTrivia(List<Trivia> trivia) {
         Objects.requireNonNull(trivia, "trivia can't be null");
 
-      this.trivia = Lists.newArrayList(trivia);
+      this.trivia = new ArrayList<>(trivia);
       return this;
     }
 
@@ -238,7 +238,7 @@ public class Token {
       Objects.requireNonNull(trivia, "trivia can't be null");
 
       if (this.trivia.isEmpty()) {
-        this.trivia = Lists.newArrayList();
+        this.trivia = new ArrayList<>();
       }
 
       this.trivia.add(trivia);

--- a/sslr-core/src/main/java/com/sonar/sslr/api/Token.java
+++ b/sslr-core/src/main/java/com/sonar/sslr/api/Token.java
@@ -24,9 +24,9 @@ import com.google.common.collect.Lists;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Objects;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Tokens are string of character like an identifier, a literal, an integer, ... which are produced by the lexer to feed the parser.
@@ -181,14 +181,15 @@ public class Token {
     }
 
     public Builder setType(TokenType type) {
-      checkNotNull(type, "type cannot be null");
+      Objects.requireNonNull(type, "type cannot be null");
 
       this.type = type;
       return this;
     }
 
     public Builder setValueAndOriginalValue(String valueAndOriginalValue) {
-      checkNotNull(valueAndOriginalValue, "valueAndOriginalValue cannot be null");
+      Objects.requireNonNull(valueAndOriginalValue,
+          "valueAndOriginalValue cannot be null");
 
       this.value = valueAndOriginalValue;
       this.originalValue = valueAndOriginalValue;
@@ -196,8 +197,8 @@ public class Token {
     }
 
     public Builder setValueAndOriginalValue(String value, String originalValue) {
-      checkNotNull(value, "value cannot be null");
-      checkNotNull(originalValue, "originalValue cannot be null");
+      Objects.requireNonNull(value, "value cannot be null");
+      Objects.requireNonNull(originalValue, "originalValue cannot be null");
 
       this.value = value;
       this.originalValue = originalValue;
@@ -215,7 +216,7 @@ public class Token {
     }
 
     public Builder setURI(URI uri) {
-      checkNotNull(uri, "uri cannot be null");
+      Objects.requireNonNull(uri, "uri cannot be null");
 
       this.uri = uri;
       return this;
@@ -227,14 +228,14 @@ public class Token {
     }
 
     public Builder setTrivia(List<Trivia> trivia) {
-      checkNotNull(trivia, "trivia can't be null");
+        Objects.requireNonNull(trivia, "trivia can't be null");
 
       this.trivia = Lists.newArrayList(trivia);
       return this;
     }
 
     public Builder addTrivia(Trivia trivia) {
-      checkNotNull(trivia, "trivia can't be null");
+      Objects.requireNonNull(trivia, "trivia can't be null");
 
       if (this.trivia.isEmpty()) {
         this.trivia = Lists.newArrayList();
@@ -255,7 +256,8 @@ public class Token {
     }
 
     public Builder setCopyBook(String copyBookOriginalFileName, int copyBookOriginalLine) {
-      checkNotNull(copyBookOriginalFileName, "copyBookOriginalFileName cannot be null");
+      Objects.requireNonNull(copyBookOriginalFileName,
+          "copyBookOriginalFileName cannot be null");
 
       this.copyBook = true;
       this.copyBookOriginalFileName = copyBookOriginalFileName;
@@ -264,10 +266,10 @@ public class Token {
     }
 
     public Token build() {
-      checkNotNull(type, "type must be set");
-      checkNotNull(value, "value must be set");
-      checkNotNull(originalValue, "originalValue must be set");
-      checkNotNull(uri, "file must be set");
+      Objects.requireNonNull(type, "type must be set");
+      Objects.requireNonNull(value, "value must be set");
+      Objects.requireNonNull(originalValue, "originalValue must be set");
+      Objects.requireNonNull(uri, "file must be set");
       checkArgument(line >= 1, "line must be greater or equal than 1");
       checkArgument(column >= 0, "column must be greater or equal than 0");
 

--- a/sslr-core/src/main/java/com/sonar/sslr/api/Trivia.java
+++ b/sslr-core/src/main/java/com/sonar/sslr/api/Trivia.java
@@ -22,8 +22,8 @@ package com.sonar.sslr.api;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
+import java.util.Objects;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 public class Trivia {
@@ -100,7 +100,7 @@ public class Trivia {
   }
 
   public static Trivia createSkippedText(List<Token> tokens) {
-    checkNotNull(tokens, "tokens cannot be null");
+    Objects.requireNonNull(tokens, "tokens cannot be null");
 
     return createSkippedText(tokens.toArray(new Token[tokens.size()]));
   }

--- a/sslr-core/src/main/java/com/sonar/sslr/impl/Lexer.java
+++ b/sslr-core/src/main/java/com/sonar/sslr/impl/Lexer.java
@@ -20,7 +20,6 @@
 package com.sonar.sslr.impl;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Lists;
 import com.sonar.sslr.api.Preprocessor;
 import com.sonar.sslr.api.PreprocessorAction;
 import com.sonar.sslr.api.Token;
@@ -124,7 +123,7 @@ public class Lexer {
   }
 
   private List<Token> lex(Reader reader) {
-    tokens = Lists.newArrayList();
+    tokens = new ArrayList<>();
 
     initPreprocessors();
     CodeReader code = new CodeReader(reader, configuration);

--- a/sslr-core/src/main/java/com/sonar/sslr/impl/Lexer.java
+++ b/sslr-core/src/main/java/com/sonar/sslr/impl/Lexer.java
@@ -46,9 +46,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 import static com.sonar.sslr.api.GenericTokenType.EOF;
 
 public class Lexer {
@@ -77,7 +77,7 @@ public class Lexer {
   }
 
   public List<Token> lex(File file) {
-    checkNotNull(file, "file cannot be null");
+    Objects.requireNonNull(file, "file cannot be null");
     checkArgument(file.isFile(), "file \"%s\" must be a file", file.getAbsolutePath());
 
     try {
@@ -88,7 +88,7 @@ public class Lexer {
   }
 
   public List<Token> lex(URL url) {
-    checkNotNull(url, "url cannot be null");
+    Objects.requireNonNull(url, "url cannot be null");
 
       try {
           uri = url.toURI();
@@ -114,7 +114,7 @@ public class Lexer {
    */
   @VisibleForTesting
   public List<Token> lex(String sourceCode) {
-    checkNotNull(sourceCode, "sourceCode cannot be null");
+    Objects.requireNonNull(sourceCode, "sourceCode cannot be null");
 
     try {
       return lex(new StringReader(sourceCode));
@@ -161,7 +161,8 @@ public class Lexer {
     int i = 0;
     while (i < remainingTokens.size()) {
       PreprocessorAction action = preprocessor.process(remainingTokens.subList(i, remainingTokens.size()));
-      checkNotNull(action, "A preprocessor cannot return a null PreprocessorAction");
+      Objects.requireNonNull(action,
+          "A preprocessor cannot return a null PreprocessorAction");
 
       addTrivia(action.getTriviaToInject());
 
@@ -195,7 +196,7 @@ public class Lexer {
   }
 
   public void addTrivia(List<Trivia> trivia) {
-    checkNotNull(trivia, "trivia cannot be null");
+    Objects.requireNonNull(trivia, "trivia cannot be null");
 
     this.trivia.addAll(trivia);
   }

--- a/sslr-core/src/main/java/org/sonar/sslr/channel/ChannelCodeReaderFilter.java
+++ b/sslr-core/src/main/java/org/sonar/sslr/channel/ChannelCodeReaderFilter.java
@@ -40,6 +40,7 @@ public final class ChannelCodeReaderFilter<O> extends CodeReaderFilter<O> {
    * @param channels
    *          the different channels
    */
+  @SafeVarargs
   public ChannelCodeReaderFilter(Channel<O>... channels) {
     super();
     this.channels = channels;
@@ -54,6 +55,7 @@ public final class ChannelCodeReaderFilter<O> extends CodeReaderFilter<O> {
    * @param channels
    *          the different channels
    */
+  @SafeVarargs
   public ChannelCodeReaderFilter(O output, Channel<O>... channels) {
     super(output);
     this.channels = channels;

--- a/sslr-core/src/main/java/org/sonar/sslr/grammar/LexerfulGrammarBuilder.java
+++ b/sslr-core/src/main/java/org/sonar/sslr/grammar/LexerfulGrammarBuilder.java
@@ -19,7 +19,6 @@
  */
 package org.sonar.sslr.grammar;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.sonar.sslr.api.Grammar;
@@ -41,6 +40,7 @@ import org.sonar.sslr.internal.vm.lexerful.TokenValueExpression;
 import org.sonar.sslr.internal.vm.lexerful.TokensBridgeExpression;
 
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * A builder for creating <a href="http://en.wikipedia.org/wiki/Parsing_expression_grammar">Parsing Expression Grammars</a> for lexerful parsing.
@@ -258,7 +258,7 @@ public class LexerfulGrammarBuilder extends GrammarBuilder {
   }
 
   protected ParsingExpression convertToExpression(Object e) {
-    Preconditions.checkNotNull(e, "Parsing expression can't be null");
+    Objects.requireNonNull(e, "Parsing expression can't be null");
     final ParsingExpression result;
     if (e instanceof ParsingExpression) {
       result = (ParsingExpression) e;

--- a/sslr-core/src/main/java/org/sonar/sslr/grammar/LexerlessGrammarBuilder.java
+++ b/sslr-core/src/main/java/org/sonar/sslr/grammar/LexerlessGrammarBuilder.java
@@ -19,7 +19,6 @@
  */
 package org.sonar.sslr.grammar;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import com.sonar.sslr.api.TokenType;
 import com.sonar.sslr.api.Trivia.TriviaKind;
@@ -34,6 +33,7 @@ import org.sonar.sslr.internal.vm.TriviaExpression;
 import org.sonar.sslr.parser.LexerlessGrammar;
 
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * A builder for creating <a href="http://en.wikipedia.org/wiki/Parsing_expression_grammar">Parsing Expression Grammars</a> for lexerless parsing.
@@ -151,7 +151,7 @@ public class LexerlessGrammarBuilder extends GrammarBuilder {
   }
 
   protected ParsingExpression convertToExpression(Object e) {
-    Preconditions.checkNotNull(e, "Parsing expression can't be null");
+    Objects.requireNonNull(e, "Parsing expression can't be null");
     final ParsingExpression result;
     if (e instanceof ParsingExpression) {
       result = (ParsingExpression) e;

--- a/sslr-core/src/main/java/org/sonar/sslr/internal/ast/select/ListAstSelect.java
+++ b/sslr-core/src/main/java/org/sonar/sslr/internal/ast/select/ListAstSelect.java
@@ -19,13 +19,12 @@
  */
 package org.sonar.sslr.internal.ast.select;
 
-import org.sonar.sslr.ast.AstSelect;
-
 import com.google.common.base.Predicate;
-import com.google.common.collect.Lists;
 import com.sonar.sslr.api.AstNode;
 import com.sonar.sslr.api.AstNodeType;
+import org.sonar.sslr.ast.AstSelect;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
@@ -41,7 +40,7 @@ public class ListAstSelect implements AstSelect {
   }
 
   public AstSelect children() {
-    List<AstNode> result = Lists.newArrayList();
+    List<AstNode> result = new ArrayList<>();
     for (AstNode node : list) {
       result.addAll(node.getChildren());
     }
@@ -49,7 +48,7 @@ public class ListAstSelect implements AstSelect {
   }
 
   public AstSelect children(AstNodeType type) {
-    List<AstNode> result = Lists.newArrayList();
+    List<AstNode> result = new ArrayList<>();
     for (AstNode node : list) {
       // Don't use "getChildren(type)", because under the hood it will create an array of types and new List to keep the result
       for (AstNode child : node.getChildren()) {
@@ -63,7 +62,7 @@ public class ListAstSelect implements AstSelect {
   }
 
   public AstSelect children(AstNodeType... types) {
-    List<AstNode> result = Lists.newArrayList();
+    List<AstNode> result = new ArrayList<>();
     for (AstNode node : list) {
       // Don't use "getChildren(type)", because it will create new List to keep the result
       for (AstNode child : node.getChildren()) {
@@ -76,7 +75,7 @@ public class ListAstSelect implements AstSelect {
   }
 
   public AstSelect nextSibling() {
-    List<AstNode> result = Lists.newArrayList();
+    List<AstNode> result = new ArrayList<>();
     for (AstNode node : list) {
       node = node.getNextSibling();
       if (node != null) {
@@ -87,7 +86,7 @@ public class ListAstSelect implements AstSelect {
   }
 
   public AstSelect previousSibling() {
-    List<AstNode> result = Lists.newArrayList();
+    List<AstNode> result = new ArrayList<>();
     for (AstNode node : list) {
       node = node.getPreviousSibling();
       if (node != null) {
@@ -98,7 +97,7 @@ public class ListAstSelect implements AstSelect {
   }
 
   public AstSelect parent() {
-    List<AstNode> result = Lists.newArrayList();
+    List<AstNode> result = new ArrayList<>();
     for (AstNode node : list) {
       node = node.getParent();
       if (node != null) {
@@ -109,7 +108,7 @@ public class ListAstSelect implements AstSelect {
   }
 
   public AstSelect firstAncestor(AstNodeType type) {
-    List<AstNode> result = Lists.newArrayList();
+    List<AstNode> result = new ArrayList<>();
     for (AstNode node : list) {
       node = node.getParent();
       while (node != null && node.getType() != type) {
@@ -123,7 +122,7 @@ public class ListAstSelect implements AstSelect {
   }
 
   public AstSelect firstAncestor(AstNodeType... types) {
-    List<AstNode> result = Lists.newArrayList();
+    List<AstNode> result = new ArrayList<>();
     for (AstNode node : list) {
       node = node.getParent();
       while (node != null && !node.is(types)) {
@@ -137,7 +136,7 @@ public class ListAstSelect implements AstSelect {
   }
 
   public AstSelect descendants(AstNodeType type) {
-    List<AstNode> result = Lists.newArrayList();
+    List<AstNode> result = new ArrayList<>();
     for (AstNode node : list) {
       result.addAll(node.getDescendants(type));
     }
@@ -145,7 +144,7 @@ public class ListAstSelect implements AstSelect {
   }
 
   public AstSelect descendants(AstNodeType... types) {
-    List<AstNode> result = Lists.newArrayList();
+    List<AstNode> result = new ArrayList<>();
     for (AstNode node : list) {
       result.addAll(node.getDescendants(types));
     }
@@ -161,7 +160,7 @@ public class ListAstSelect implements AstSelect {
   }
 
   public AstSelect filter(AstNodeType type) {
-    List<AstNode> result = Lists.newArrayList();
+    List<AstNode> result = new ArrayList<>();
     for (AstNode node : list) {
       if (node.getType() == type) {
         result.add(node);
@@ -171,7 +170,7 @@ public class ListAstSelect implements AstSelect {
   }
 
   public AstSelect filter(AstNodeType... types) {
-    List<AstNode> result = Lists.newArrayList();
+    List<AstNode> result = new ArrayList<>();
     for (AstNode node : list) {
       if (node.is(types)) {
         result.add(node);
@@ -181,7 +180,7 @@ public class ListAstSelect implements AstSelect {
   }
 
   public AstSelect filter(Predicate<AstNode> predicate) {
-    List<AstNode> result = Lists.newArrayList();
+    List<AstNode> result = new ArrayList<>();
     for (AstNode node : list) {
       if (predicate.apply(node)) {
         result.add(node);

--- a/sslr-core/src/main/java/org/sonar/sslr/internal/ast/select/SingleAstSelect.java
+++ b/sslr-core/src/main/java/org/sonar/sslr/internal/ast/select/SingleAstSelect.java
@@ -19,14 +19,13 @@
  */
 package org.sonar.sslr.internal.ast.select;
 
-import org.sonar.sslr.ast.AstSelect;
-
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterators;
-import com.google.common.collect.Lists;
 import com.sonar.sslr.api.AstNode;
 import com.sonar.sslr.api.AstNodeType;
+import org.sonar.sslr.ast.AstSelect;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
@@ -59,7 +58,7 @@ public class SingleAstSelect implements AstSelect {
       }
       return AstSelectFactory.empty();
     } else if (node.getNumberOfChildren() > 1) {
-      List<AstNode> result = Lists.newArrayList();
+      List<AstNode> result = new ArrayList<>();
       // Don't use "getChildren(type)", because under the hood it will create an array of types and new List to keep the result
       for (AstNode child : node.getChildren()) {
         // Don't use "is(type)", because under the hood it will create an array of types
@@ -81,7 +80,7 @@ public class SingleAstSelect implements AstSelect {
       }
       return AstSelectFactory.empty();
     } else if (node.getNumberOfChildren() > 1) {
-      List<AstNode> result = Lists.newArrayList();
+      List<AstNode> result = new ArrayList<>();
       // Don't use "getChildren(type)", because it will create new List to keep the result
       for (AstNode child : node.getChildren()) {
         if (child.is(types)) {

--- a/sslr-core/src/main/java/org/sonar/sslr/internal/matchers/AstCreator.java
+++ b/sslr-core/src/main/java/org/sonar/sslr/internal/matchers/AstCreator.java
@@ -20,7 +20,6 @@
 package org.sonar.sslr.internal.matchers;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Lists;
 import com.sonar.sslr.api.AstNode;
 import com.sonar.sslr.api.GenericTokenType;
 import com.sonar.sslr.api.Token;
@@ -38,6 +37,7 @@ import org.sonar.sslr.text.TextLocation;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -56,7 +56,7 @@ public final class AstCreator {
 
   private final TextCharSequence input;
   private final Token.Builder tokenBuilder = Token.builder();
-  private final List<Trivia> trivias = Lists.newArrayList();
+  private final List<Trivia> trivias = new ArrayList<>();
 
   public static AstNode create(ParsingResult parsingResult, Text input) {
     AstNode astNode = new AstCreator(input).visit(parsingResult.getParseTreeRoot());
@@ -142,7 +142,7 @@ public final class AstCreator {
 
   private AstNode visitNonTerminal(ParseNode node) {
     MutableParsingRule ruleMatcher = (MutableParsingRule) node.getMatcher();
-    List<AstNode> astNodes = Lists.newArrayList();
+    List<AstNode> astNodes = new ArrayList<>();
     for (ParseNode child : node.getChildren()) {
       AstNode astNode = visit(child);
       if (astNode != null) {

--- a/sslr-core/src/main/java/org/sonar/sslr/internal/matchers/ImmutableInputBuffer.java
+++ b/sslr-core/src/main/java/org/sonar/sslr/internal/matchers/ImmutableInputBuffer.java
@@ -19,8 +19,7 @@
  */
 package org.sonar.sslr.internal.matchers;
 
-import com.google.common.collect.Lists;
-
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -36,7 +35,7 @@ public class ImmutableInputBuffer implements InputBuffer {
   public ImmutableInputBuffer(char[] buffer) {
     this.buffer = buffer;
 
-    List<Integer> newlines = Lists.newArrayList();
+    List<Integer> newlines = new ArrayList<>();
     int i = 0;
     newlines.add(0);
     while (i < buffer.length) {

--- a/sslr-core/src/main/java/org/sonar/sslr/internal/matchers/LexerfulAstCreator.java
+++ b/sslr-core/src/main/java/org/sonar/sslr/internal/matchers/LexerfulAstCreator.java
@@ -19,12 +19,12 @@
  */
 package org.sonar.sslr.internal.matchers;
 
-import com.google.common.collect.Lists;
 import com.sonar.sslr.api.AstNode;
 import com.sonar.sslr.api.Token;
 import com.sonar.sslr.impl.matcher.RuleDefinition;
 import org.sonar.sslr.internal.vm.lexerful.TokenTypeExpression;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class LexerfulAstCreator {
@@ -51,7 +51,7 @@ public class LexerfulAstCreator {
   }
 
   private AstNode visitNonTerminal(ParseNode node) {
-    List<AstNode> astNodes = Lists.newArrayList();
+    List<AstNode> astNodes = new ArrayList<>();
     for (ParseNode child : node.getChildren()) {
       AstNode astNode = visit(child);
       if (astNode == null) {

--- a/sslr-core/src/main/java/org/sonar/sslr/internal/text/TextUtils.java
+++ b/sslr-core/src/main/java/org/sonar/sslr/internal/text/TextUtils.java
@@ -19,9 +19,9 @@
  */
 package org.sonar.sslr.internal.text;
 
-import com.google.common.collect.Lists;
 import org.sonar.sslr.text.Texts;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public final class TextUtils {
@@ -32,7 +32,7 @@ public final class TextUtils {
   private static final int[] EMPTY_INT_ARRAY = new int[0];
 
   public static int[] computeLines(char[] chars) {
-    List<Integer> newlines = Lists.newArrayList();
+    List<Integer> newlines = new ArrayList<>();
     int i = 0;
     while (i < chars.length) {
       if (isEndOfLine(chars, i)) {

--- a/sslr-core/src/main/java/org/sonar/sslr/internal/vm/ErrorTreeNode.java
+++ b/sslr-core/src/main/java/org/sonar/sslr/internal/vm/ErrorTreeNode.java
@@ -19,15 +19,15 @@
  */
 package org.sonar.sslr.internal.vm;
 
-import com.google.common.collect.Lists;
 import org.sonar.sslr.internal.matchers.MatcherPathElement;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class ErrorTreeNode {
 
   public MatcherPathElement pathElement;
-  public List<ErrorTreeNode> children = Lists.newArrayList();
+  public List<ErrorTreeNode> children = new ArrayList<>();
 
   public static ErrorTreeNode buildTree(List<List<MatcherPathElement>> paths) {
     ErrorTreeNode root = new ErrorTreeNode();

--- a/sslr-core/src/main/java/org/sonar/sslr/internal/vm/MachineStack.java
+++ b/sslr-core/src/main/java/org/sonar/sslr/internal/vm/MachineStack.java
@@ -19,12 +19,11 @@
  */
 package org.sonar.sslr.internal.vm;
 
-import com.google.common.collect.Lists;
 import org.sonar.sslr.internal.matchers.Matcher;
 import org.sonar.sslr.internal.matchers.ParseNode;
 
 import javax.annotation.Nullable;
-
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -50,7 +49,7 @@ public class MachineStack {
 
   private MachineStack(MachineStack parent) {
     this.parent = parent;
-    this.subNodes = Lists.newArrayList();
+    this.subNodes = new ArrayList<>();
   }
 
   public MachineStack parent() {

--- a/sslr-core/src/main/java/org/sonar/sslr/internal/vm/MutableGrammarCompiler.java
+++ b/sslr-core/src/main/java/org/sonar/sslr/internal/vm/MutableGrammarCompiler.java
@@ -19,10 +19,11 @@
  */
 package org.sonar.sslr.internal.vm;
 
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.sonar.sslr.grammar.GrammarRuleKey;
 
+import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
@@ -33,12 +34,12 @@ public class MutableGrammarCompiler extends CompilationHandler {
     return new MutableGrammarCompiler().doCompile(rule);
   }
 
-  private final Queue<CompilableGrammarRule> compilationQueue = Lists.newLinkedList();
+  private final Queue<CompilableGrammarRule> compilationQueue = new ArrayDeque<>();
   private final Map<GrammarRuleKey, CompilableGrammarRule> matchers = Maps.newHashMap();
   private final Map<GrammarRuleKey, Integer> offsets = Maps.newHashMap();
 
   private CompiledGrammar doCompile(CompilableGrammarRule start) {
-    List<Instruction> instructions = Lists.newArrayList();
+    List<Instruction> instructions = new ArrayList<>();
 
     // Compile
 

--- a/sslr-core/src/main/java/org/sonar/sslr/internal/vm/SequenceExpression.java
+++ b/sslr-core/src/main/java/org/sonar/sslr/internal/vm/SequenceExpression.java
@@ -19,8 +19,7 @@
  */
 package org.sonar.sslr.internal.vm;
 
-import com.google.common.collect.Lists;
-
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -42,7 +41,7 @@ public class SequenceExpression implements ParsingExpression {
    * </pre>
    */
   public Instruction[] compile(CompilationHandler compiler) {
-    List<Instruction> result = Lists.newArrayList();
+    List<Instruction> result = new ArrayList<>();
     for (ParsingExpression subExpression : subExpressions) {
       Instruction.addAll(result, compiler.compile(subExpression));
     }

--- a/sslr-core/src/main/java/org/sonar/sslr/parser/ParseError.java
+++ b/sslr-core/src/main/java/org/sonar/sslr/parser/ParseError.java
@@ -19,8 +19,9 @@
  */
 package org.sonar.sslr.parser;
 
-import com.google.common.base.Preconditions;
 import org.sonar.sslr.internal.matchers.InputBuffer;
+
+import java.util.Objects;
 
 /**
  * Describes an error, which is occurred during parse.
@@ -36,7 +37,7 @@ public class ParseError {
   private final int errorIndex;
 
   public ParseError(InputBuffer inputBuffer, int errorIndex) {
-    this.inputBuffer = Preconditions.checkNotNull(inputBuffer, "inputBuffer");
+    this.inputBuffer = Objects.requireNonNull(inputBuffer, "inputBuffer");
     this.errorIndex = errorIndex;
   }
 

--- a/sslr-core/src/main/java/org/sonar/sslr/parser/ParseRunner.java
+++ b/sslr-core/src/main/java/org/sonar/sslr/parser/ParseRunner.java
@@ -19,12 +19,13 @@
  */
 package org.sonar.sslr.parser;
 
-import com.google.common.base.Preconditions;
 import com.sonar.sslr.api.Rule;
 import org.sonar.sslr.internal.vm.CompilableGrammarRule;
 import org.sonar.sslr.internal.vm.CompiledGrammar;
 import org.sonar.sslr.internal.vm.Machine;
 import org.sonar.sslr.internal.vm.MutableGrammarCompiler;
+
+import java.util.Objects;
 
 /**
  * Performs parsing of a given grammar rule on a given input text.
@@ -38,7 +39,8 @@ public class ParseRunner {
   private final CompiledGrammar compiledGrammar;
 
   public ParseRunner(Rule rule) {
-    compiledGrammar = MutableGrammarCompiler.compile((CompilableGrammarRule) Preconditions.checkNotNull(rule, "rule"));
+    compiledGrammar = MutableGrammarCompiler.compile(
+        (CompilableGrammarRule) Objects.requireNonNull(rule, "rule"));
   }
 
   public ParsingResult parse(char[] input) {

--- a/sslr-core/src/main/java/org/sonar/sslr/parser/ParserAdapter.java
+++ b/sslr-core/src/main/java/org/sonar/sslr/parser/ParserAdapter.java
@@ -19,7 +19,6 @@
  */
 package org.sonar.sslr.parser;
 
-import com.google.common.base.Preconditions;
 import com.google.common.io.Files;
 import com.sonar.sslr.api.AstNode;
 import com.sonar.sslr.api.RecognitionException;
@@ -34,11 +33,11 @@ import org.sonar.sslr.text.PreprocessorsChain;
 import org.sonar.sslr.text.Text;
 
 import javax.annotation.Nullable;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Adapts {@link ParseRunner} to be used as {@link Parser}.
@@ -61,8 +60,8 @@ public class ParserAdapter<G extends LexerlessGrammar> extends Parser<G> {
    * @since 1.17
    */
   public ParserAdapter(Charset charset, G grammar, @Nullable PreprocessorsChain preprocessorsChain) {
-    super(Preconditions.checkNotNull(grammar, "grammar"));
-    this.charset = Preconditions.checkNotNull(charset, "charset");
+    super(Objects.requireNonNull(grammar, "grammar"));
+    this.charset = Objects.requireNonNull(charset, "charset");
     this.parseRunner = new ParseRunner(grammar.getRootRule());
     this.preprocessorsChain = preprocessorsChain;
   }

--- a/sslr-core/src/main/java/org/sonar/sslr/parser/ParsingResult.java
+++ b/sslr-core/src/main/java/org/sonar/sslr/parser/ParsingResult.java
@@ -20,11 +20,11 @@
 package org.sonar.sslr.parser;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import org.sonar.sslr.internal.matchers.InputBuffer;
 import org.sonar.sslr.internal.matchers.ParseNode;
 
 import javax.annotation.Nullable;
+import java.util.Objects;
 
 /**
  * Parsing result.
@@ -41,7 +41,7 @@ public class ParsingResult {
   private final ParseError parseError;
 
   public ParsingResult(InputBuffer inputBuffer, boolean matched, @Nullable ParseNode parseTreeRoot, @Nullable ParseError parseError) {
-    this.inputBuffer = Preconditions.checkNotNull(inputBuffer, "inputBuffer");
+    this.inputBuffer = Objects.requireNonNull(inputBuffer, "inputBuffer");
     this.matched = matched;
     this.parseTreeRoot = parseTreeRoot;
     this.parseError = parseError;

--- a/sslr-core/src/main/java/org/sonar/sslr/text/TextBuilder.java
+++ b/sslr-core/src/main/java/org/sonar/sslr/text/TextBuilder.java
@@ -19,12 +19,12 @@
  */
 package org.sonar.sslr.text;
 
-import com.google.common.collect.Lists;
 import org.sonar.sslr.internal.text.AbstractText;
 import org.sonar.sslr.internal.text.CompositeText;
 import org.sonar.sslr.internal.text.PlainText;
 import org.sonar.sslr.internal.text.TransformedText;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -38,7 +38,7 @@ public class TextBuilder {
 
   private static final Text EMPTY = new PlainText(new char[0]);
 
-  private final List<AbstractText> texts = Lists.newArrayList();
+  private final List<AbstractText> texts = new ArrayList<>();
 
   public static TextBuilder create() {
     return new TextBuilder();

--- a/sslr-core/src/test/java/org/sonar/sslr/internal/matchers/AstCreatorTest.java
+++ b/sslr-core/src/test/java/org/sonar/sslr/internal/matchers/AstCreatorTest.java
@@ -52,8 +52,10 @@ public class AstCreatorTest {
     AstNodeType realAstNodeType = mock(AstNodeType.class);
     when(ruleMatcher.getRealAstNodeType()).thenReturn(realAstNodeType);
 
-    ParseNode triviaNode = new ParseNode(0, 4, Collections.EMPTY_LIST, triviaMatcher);
-    ParseNode tokenNode = new ParseNode(4, 7, Collections.EMPTY_LIST, tokenMatcher);
+    ParseNode triviaNode = new ParseNode(0, 4,
+        Collections.<ParseNode>emptyList(), triviaMatcher);
+    ParseNode tokenNode = new ParseNode(4, 7,
+        Collections.<ParseNode>emptyList(), tokenMatcher);
     ParseNode parseTreeRoot = new ParseNode(0, 7, ImmutableList.of(triviaNode, tokenNode), ruleMatcher);
 
     InputBuffer inputBuffer = new ImmutableInputBuffer(input);
@@ -91,8 +93,10 @@ public class AstCreatorTest {
   public void should_create_tokens_without_TokenMatcher() {
     char[] input = "foobar".toCharArray();
 
-    ParseNode firstTerminal = new ParseNode(0, 3, Collections.EMPTY_LIST, null);
-    ParseNode secondTerminal = new ParseNode(3, 6, Collections.EMPTY_LIST, null);
+    ParseNode firstTerminal = new ParseNode(0, 3,
+        Collections.<ParseNode>emptyList(), null);
+    ParseNode secondTerminal = new ParseNode(3, 6,
+        Collections.<ParseNode>emptyList(), null);
     MutableParsingRule ruleMatcher = mockRuleMatcher("rule");
     AstNodeType realAstNodeType = mock(AstNodeType.class);
     when(ruleMatcher.getRealAstNodeType()).thenReturn(realAstNodeType);
@@ -138,7 +142,7 @@ public class AstCreatorTest {
     AstNodeType realAstNodeType = mock(AstNodeType.class);
     when(ruleMatcher2.getRealAstNodeType()).thenReturn(realAstNodeType);
 
-    ParseNode node = new ParseNode(0, 3, Collections.EMPTY_LIST, ruleMatcher1);
+    ParseNode node = new ParseNode(0, 3, Collections.<ParseNode>emptyList(), ruleMatcher1);
     ParseNode parseTreeRoot = new ParseNode(0, 3, ImmutableList.of(node), ruleMatcher2);
 
     InputBuffer inputBuffer = new ImmutableInputBuffer(input);

--- a/sslr-toolkit/src/main/java/org/sonar/sslr/internal/toolkit/ToolkitPresenter.java
+++ b/sslr-toolkit/src/main/java/org/sonar/sslr/internal/toolkit/ToolkitPresenter.java
@@ -35,8 +35,8 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.lang.Thread.UncaughtExceptionHandler;
+import java.util.Objects;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 public class ToolkitPresenter {
@@ -51,7 +51,7 @@ public class ToolkitPresenter {
   }
 
   public void setView(ToolkitView view) {
-    checkNotNull(view);
+    Objects.requireNonNull(view);
     this.view = view;
   }
 

--- a/sslr-toolkit/src/main/java/org/sonar/sslr/internal/toolkit/ToolkitViewImpl.java
+++ b/sslr-toolkit/src/main/java/org/sonar/sslr/internal/toolkit/ToolkitViewImpl.java
@@ -72,8 +72,8 @@ import java.io.File;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 
 public class ToolkitViewImpl extends JFrame implements ToolkitView {
 
@@ -126,7 +126,7 @@ public class ToolkitViewImpl extends JFrame implements ToolkitView {
   private boolean astSelectionEventDisabled = false;
 
   public ToolkitViewImpl(ToolkitPresenter presenter) {
-    checkNotNull(presenter);
+    Objects.requireNonNull(presenter);
     this.presenter = presenter;
 
     initComponents();
@@ -256,7 +256,7 @@ public class ToolkitViewImpl extends JFrame implements ToolkitView {
     try {
       sourceCodeTextCursorMovedEventDisabled = true;
 
-      checkNotNull(htmlHighlightedSourceCode);
+      Objects.requireNonNull(htmlHighlightedSourceCode);
 
       StringBuilder sb = new StringBuilder();
       sb.append("<html><head><style type=\"text/css\">");
@@ -306,7 +306,7 @@ public class ToolkitViewImpl extends JFrame implements ToolkitView {
 
   @Override
   public void displayXml(String xml) {
-    checkNotNull(xml);
+    Objects.requireNonNull(xml);
 
     xmlTextArea.setText(xml);
   }
@@ -321,7 +321,7 @@ public class ToolkitViewImpl extends JFrame implements ToolkitView {
 
   @Override
   public void scrollSourceCodeTo(final Point point) {
-    checkNotNull(point);
+    Objects.requireNonNull(point);
 
     // http://stackoverflow.com/questions/8789371/java-jtextpane-jscrollpane-de-activate-automatic-scrolling
     SwingUtilities.invokeLater(new Runnable() {
@@ -392,7 +392,7 @@ public class ToolkitViewImpl extends JFrame implements ToolkitView {
 
   @Override
   public void highlightSourceCode(AstNode astNode) {
-    checkNotNull(astNode);
+    Objects.requireNonNull(astNode);
 
     if (!astNode.hasToken()) {
       return;

--- a/sslr-toolkit/src/main/java/org/sonar/sslr/internal/toolkit/ToolkitViewImpl.java
+++ b/sslr-toolkit/src/main/java/org/sonar/sslr/internal/toolkit/ToolkitViewImpl.java
@@ -20,7 +20,6 @@
 package org.sonar.sslr.internal.toolkit;
 
 import com.google.common.base.Throwables;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.sonar.sslr.api.AstNode;
 import com.sonar.sslr.api.Token;
@@ -69,6 +68,7 @@ import java.awt.event.ActionListener;
 import java.awt.event.FocusAdapter;
 import java.awt.event.FocusEvent;
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
@@ -505,7 +505,7 @@ public class ToolkitViewImpl extends JFrame implements ToolkitView {
 
   @Override
   public List<AstNode> getSelectedAstNodes() {
-    List<AstNode> acc = Lists.newArrayList();
+    List<AstNode> acc = new ArrayList<>();
 
     TreePath[] selectedPaths = astTree.getSelectionPaths();
     if (selectedPaths != null) {

--- a/sslr-toolkit/src/main/java/org/sonar/sslr/toolkit/Toolkit.java
+++ b/sslr-toolkit/src/main/java/org/sonar/sslr/toolkit/Toolkit.java
@@ -54,7 +54,7 @@ public class Toolkit {
 
       @Override
       public List<ConfigurationProperty> getProperties() {
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
       }
 
       @Override

--- a/sslr-toolkit/src/test/java/org/sonar/sslr/internal/toolkit/ToolkitPresenterTest.java
+++ b/sslr-toolkit/src/test/java/org/sonar/sslr/internal/toolkit/ToolkitPresenterTest.java
@@ -21,7 +21,6 @@ package org.sonar.sslr.internal.toolkit;
 
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 import com.sonar.sslr.api.AstNode;
 import com.sonar.sslr.api.GenericTokenType;
 import com.sonar.sslr.api.Token;
@@ -38,6 +37,7 @@ import java.io.PrintWriter;
 import java.lang.Thread.UncaughtExceptionHandler;
 import java.net.URI;
 import java.nio.charset.Charset;
+import java.util.Arrays;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.mockito.Matchers.any;
@@ -374,7 +374,7 @@ public class ToolkitPresenterTest {
     ToolkitView view = mock(ToolkitView.class);
     AstNode firstAstNode = mock(AstNode.class);
     AstNode secondAstNode = mock(AstNode.class);
-    when(view.getSelectedAstNodes()).thenReturn(Lists.newArrayList(firstAstNode, secondAstNode));
+    when(view.getSelectedAstNodes()).thenReturn(Arrays.asList(firstAstNode, secondAstNode));
 
     ToolkitPresenter presenter = new ToolkitPresenter(mock(ConfigurationModel.class), mock(SourceCodeModel.class));
     presenter.setView(view);

--- a/sslr-toolkit/src/test/java/org/sonar/sslr/toolkit/ConfigurationPropertyTest.java
+++ b/sslr-toolkit/src/test/java/org/sonar/sslr/toolkit/ConfigurationPropertyTest.java
@@ -72,7 +72,7 @@ public class ConfigurationPropertyTest {
     new ConfigurationProperty("", "", "", new ValidationCallback() {
 
       public String validate(String newValueCandidate) {
-        return newValueCandidate.length() == 0 ? "" : "The value \"" + newValueCandidate + "\" did not pass validation: Not valid!";
+        return newValueCandidate.isEmpty() ? "" : "The value \"" + newValueCandidate + "\" did not pass validation: Not valid!";
       }
 
     }).setValue("foo");

--- a/sslr-xpath/src/main/java/com/sonar/sslr/impl/xpath/AstNodeNavigator.java
+++ b/sslr-xpath/src/main/java/com/sonar/sslr/impl/xpath/AstNodeNavigator.java
@@ -33,8 +33,6 @@ import java.util.Objects;
 @SuppressWarnings("serial")
 public class AstNodeNavigator extends DefaultNavigator {
 
-  private static final Iterator EMPTY_ITERATOR = Collections.EMPTY_LIST.iterator();
-
   private transient AstNode documentNode = null;
 
   public void reset() {
@@ -195,7 +193,7 @@ public class AstNodeNavigator extends DefaultNavigator {
       AstNode astNode = (AstNode) contextNode;
       return astNode.getChildren().iterator();
     } else if (isAttribute(contextNode)) {
-      return EMPTY_ITERATOR;
+      return Collections.emptyIterator();
     } else {
       throw new UnsupportedOperationException("Unsupported context object type for child axis \"" + contextNode.getClass().getSimpleName() + "\": " + contextNode);
     }
@@ -220,7 +218,7 @@ public class AstNodeNavigator extends DefaultNavigator {
     if (isElement(contextNode)) {
       AstNode astNode = (AstNode) contextNode;
       AstNode parent = astNode.getParent();
-      return parent == null ? EMPTY_ITERATOR : new SingleObjectIterator(parent);
+      return parent == null ? Collections.emptyIterator() : new SingleObjectIterator(parent);
     } else if (isAttribute(contextNode)) {
       Attribute attribute = (Attribute) contextNode;
       return new SingleObjectIterator(attribute.getAstNode());
@@ -234,12 +232,12 @@ public class AstNodeNavigator extends DefaultNavigator {
     if (isElement(contextNode)) {
       AstNode astNode = (AstNode) contextNode;
       if (!astNode.hasToken()) {
-        return EMPTY_ITERATOR;
+        return Collections.emptyIterator();
       } else {
         return Iterators.forArray(new Attribute("tokenLine", astNode), new Attribute("tokenColumn", astNode), new Attribute("tokenValue", astNode));
       }
     } else if (isAttribute(contextNode)) {
-      return EMPTY_ITERATOR;
+      return Collections.emptyIterator();
     } else {
       throw new UnsupportedOperationException("Unsupported context object type for attribute axis \"" + contextNode.getClass().getSimpleName() + "\": " + contextNode);
     }

--- a/sslr-xpath/src/main/java/com/sonar/sslr/impl/xpath/AstNodeNavigator.java
+++ b/sslr-xpath/src/main/java/com/sonar/sslr/impl/xpath/AstNodeNavigator.java
@@ -28,8 +28,7 @@ import org.jaxen.util.SingleObjectIterator;
 
 import java.util.Collections;
 import java.util.Iterator;
-
-import static com.google.common.base.Preconditions.checkNotNull;
+import java.util.Objects;
 
 @SuppressWarnings("serial")
 public class AstNodeNavigator extends DefaultNavigator {
@@ -184,7 +183,9 @@ public class AstNodeNavigator extends DefaultNavigator {
   @Override
   public Object getDocumentNode(Object contextNode) {
     computeDocumentNode(contextNode);
-    checkNotNull(documentNode, "Unable to compute the document node from the context node \"" + contextNode.getClass().getSimpleName() + "\": " + contextNode);
+    Objects.requireNonNull(documentNode,
+        "Unable to compute the document node from the context node \""
+            + contextNode.getClass().getSimpleName() + "\": " + contextNode);
     return documentNode;
   }
 


### PR DESCRIPTION
This has required changing the parent pom version to 19.

But this way the calls to Closeables.closeQuietly() could be removed.

Also, while we are at it, replace all invocations of:
- Preconditions.checkNonNull() with Objects.requireNonNull();
- Lists.newArrayList(...) with new ArrayList<>() (where appropriate).

Also update Collections usage.
