### PR TITLE
CodeBuffer: implement .subSequence(), plus tests

### DIFF
--- a/sslr-core/src/main/java/org/sonar/sslr/channel/CodeBuffer.java
+++ b/sslr-core/src/main/java/org/sonar/sslr/channel/CodeBuffer.java
@@ -27,6 +27,7 @@ import java.io.FilterReader;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
+import java.util.Arrays;
 
 /**
  * The CodeBuffer class provides all the basic features required to manipulate a source code character stream. Those features are :
@@ -203,7 +204,9 @@ public class CodeBuffer implements CharSequence {
 
   @Override
   public final CharSequence subSequence(int start, int end) {
-    throw new UnsupportedOperationException();
+    final int realStart = bufferPosition + start;
+    final int realEnd = bufferPosition + end;
+    return new String(Arrays.copyOfRange(buffer, realStart, realEnd));
   }
 
   @Override

--- a/sslr-core/src/test/java/org/sonar/sslr/channel/CodeBufferTest.java
+++ b/sslr-core/src/test/java/org/sonar/sslr/channel/CodeBufferTest.java
@@ -264,6 +264,29 @@ public class CodeBufferTest {
     assertThat(code.pop(), is( -1));
   }
 
+    @Test
+    public void testSubSequence()
+    {
+        final CodeReaderConfiguration cfg = new CodeReaderConfiguration();
+        final String input = "some pretty short input\njust for kicks";
+        final CodeBuffer code = new CodeBuffer(input, cfg);
+
+        assertThat(code.subSequence(0, 4).toString(), is("some"));
+        assertThat(code.subSequence(24, 38).toString(), is("just for kicks"));
+
+        // Shift by one; the subsequence should shift accordingly
+        code.pop();
+        assertThat(code.subSequence(0, 4).toString(), is("ome "));
+
+        // Shift four more
+        code.pop();
+        code.pop();
+        code.pop();
+        code.pop();
+        assertThat(code.subSequence(0, 12).toString(), is("pretty short"));
+        assertThat(code.subSequence(13, 18).toString(), is("input"));
+    }
+
   /**
    * Backward compatibility with a COBOL plugin: filter returns 0 instead of -1, when end of the stream has been reached.
    */


### PR DESCRIPTION
There is no reason why CodeBuffer isn't able to support it.

Just use a CharBuffer to .wrap() the buffer, and use this CharBuffer's
.subSequence() with the indices adjusted according to the buffer's current
position.
