### PR TITLE
Factorize call to string.length() in StringExpression

### DIFF
--- a/sslr-core/src/main/java/org/sonar/sslr/internal/vm/StringExpression.java
+++ b/sslr-core/src/main/java/org/sonar/sslr/internal/vm/StringExpression.java
@@ -24,24 +24,26 @@ import org.sonar.sslr.internal.matchers.Matcher;
 public class StringExpression extends NativeExpression implements Matcher {
 
   private final String string;
+  private final int length;
 
   public StringExpression(String string) {
     this.string = string;
+    this.length = string.length();
   }
 
   @Override
   public void execute(Machine machine) {
-    if (machine.length() < string.length()) {
+    if (machine.length() < length) {
       machine.backtrack();
       return;
     }
-    for (int i = 0; i < string.length(); i++) {
+    for (int i = 0; i < length; i++) {
       if (machine.charAt(i) != string.charAt(i)) {
         machine.backtrack();
         return;
       }
     }
-    machine.createLeafNode(this, string.length());
+    machine.createLeafNode(this, length);
     machine.jump(1);
   }
 


### PR DESCRIPTION
Method was called 3 times for each call to execute.
By factorizing it to when object is constructed the number of invocation is really reduced
and we can see a small gain in performance on small project.
