### PR TITLE
Getting rid of Closeables.closeQuietly references.

### DIFF
--- a/sslr-core/src/main/java/com/sonar/sslr/impl/Lexer.java
+++ b/sslr-core/src/main/java/com/sonar/sslr/impl/Lexer.java
@@ -88,16 +88,12 @@ public class Lexer {
   public List<Token> lex(URL url) {
     checkNotNull(url, "url cannot be null");
 
-    InputStreamReader reader = null;
-    try {
+    try (InputStreamReader reader = new InputStreamReader(url.openStream(), charset)) {
       this.uri = url.toURI();
-
-      reader = new InputStreamReader(url.openStream(), charset);
       return lex(reader);
+
     } catch (Exception e) {
       throw new LexerException("Unable to lex url: " + getURI(), e);
-    } finally {
-      Closeables.closeQuietly(reader);
     }
   }
 

--- a/sslr-core/src/main/java/org/sonar/sslr/channel/CodeBuffer.java
+++ b/sslr-core/src/main/java/org/sonar/sslr/channel/CodeBuffer.java
@@ -66,11 +66,11 @@ public class CodeBuffer implements CharSequence {
       cursor = new Cursor();
       tabWidth = configuration.getTabWidth();
 
-      Reader filteredReader = initialCodeReader;
+      Reader filteredReader = reader;
 
       /* Setup the filters on the reader */
       for (CodeReaderFilter<?> codeReaderFilter : configuration.getCodeReaderFilters()) {
-        filteredReader = new Filter(reader, codeReaderFilter, configuration);
+        filteredReader = new Filter(filteredReader, codeReaderFilter, configuration);
       }
 
       /* Make sure to close the filtered reader when done (cascading through the lot) */

--- a/sslr-core/src/main/java/org/sonar/sslr/channel/CodeBuffer.java
+++ b/sslr-core/src/main/java/org/sonar/sslr/channel/CodeBuffer.java
@@ -59,24 +59,27 @@ public class CodeBuffer implements CharSequence {
    * Note that this constructor will read everything from reader and will close it.
    */
   protected CodeBuffer(Reader initialCodeReader, CodeReaderConfiguration configuration) {
-    Reader reader = null;
 
-    try {
+    /* Make sure the reader passed-in gets closed when done. */
+    try (Reader reader = initialCodeReader) {
       lastChar = -1;
       cursor = new Cursor();
       tabWidth = configuration.getTabWidth();
 
+      Reader filteredReader = initialCodeReader;
+
       /* Setup the filters on the reader */
-      reader = initialCodeReader;
       for (CodeReaderFilter<?> codeReaderFilter : configuration.getCodeReaderFilters()) {
-        reader = new Filter(reader, codeReaderFilter, configuration);
+        filteredReader = new Filter(reader, codeReaderFilter, configuration);
       }
 
-      buffer = CharStreams.toString(reader).toCharArray();
+      /* Make sure to close the filtered reader when done (cascading through the lot) */
+      try (Reader usedReader = filteredReader) {
+        buffer = CharStreams.toString(usedReader).toCharArray();
+      }
+
     } catch (IOException e) {
       throw new ChannelException(e.getMessage(), e);
-    } finally {
-      Closeables.closeQuietly(reader);
     }
   }
 


### PR DESCRIPTION
This causes problems in different versions of guava that may or may not be on the classpath during analysis. A slightly more targeted replacement for #1.