### PR TITLE
Move the method lookup to the block which uses it

### DIFF
--- a/sslr-core/src/main/java/com/sonar/sslr/impl/typed/SyntaxTreeCreator.java
+++ b/sslr-core/src/main/java/com/sonar/sslr/impl/typed/SyntaxTreeCreator.java
@@ -72,7 +72,6 @@ public class SyntaxTreeCreator<T> {
   private Object visitNonTerminal(ParseNode node) {
     MutableParsingRule rule = (MutableParsingRule) node.getMatcher();
     GrammarRuleKey ruleKey = rule.getRuleKey();
-    Method method = mapping.actionForRuleKey(ruleKey);
 
     Object result;
 
@@ -96,6 +95,7 @@ public class SyntaxTreeCreator<T> {
       }
 
     } else {
+      Method method = mapping.actionForRuleKey(ruleKey);
       List<Object> convertedChildren = new ArrayList<>();
       for (ParseNode child : node.getChildren()) {
         convertedChildren.add(visit(child));


### PR DESCRIPTION
Another micro-optimisation: it probably doesn't have a measurable impact, but I was stepping through the visitor in the debugger, and it's also one less step for each visit…