### PR TITLE
SSLR-397 Remove burgr from CI pipelines

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,10 +7,6 @@ env:
   ARTIFACTORY_DEPLOY_PASSWORD: VAULT[development/artifactory/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-qa-deployer access_token]
   #Possible values for ARTIFACTORY_DEPLOY_REPO: sonarsource-private-qa, sonarsource-public-qa
   ARTIFACTORY_DEPLOY_REPO: sonarsource-public-qa
-  # burgr notification
-  BURGR_URL: VAULT[development/kv/data/burgr data.url]
-  BURGR_USERNAME: VAULT[development/kv/data/burgr data.cirrus_username]
-  BURGR_PASSWORD: VAULT[development/kv/data/burgr data.cirrus_password]
   # Use bash (instead of sh on linux or cmd.exe on windows)
   CIRRUS_SHELL: bash
 
@@ -54,8 +50,6 @@ promote_task:
   env:
     ARTIFACTORY_PROMOTE_ACCESS_TOKEN: VAULT[development/artifactory/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-promoter access_token]
     GITHUB_TOKEN: VAULT[development/github/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-promotion token]
-    #artifacts that will have downloadable links in burgr
-    ARTIFACTS: "org.sonarsource.sslr:sslr:jar" 
   maven_cache:
     folder: ${CIRRUS_WORKING_DIR}/.m2/repository
   script: cirrus_promote_maven


### PR DESCRIPTION
 - The repo has no existing subscriptions from slack using burger (I searched for messages `from:@Burgr` in all channels).
 -  No direct calls to the burger API that need to be updated are present in the repo.
 - The repo is using `cirrus_promote_maven` and GH commit status should already be handled [here](https://github.com/SonarSource/ci-common-scripts/blob/99e4f81a2f98cdf8957598dcbfbdc339612fc539/src/cirrus_promote_maven#L32-L36). Unfortunately, the build is failing on master at the moment. My guess is that it is related to the Java version (being updated in #45), but I didn't dig deeper.
 - The `ARTIFACTS` environment variable used to be read by [the deprecated `burgr-notify-promotion` script](https://github.com/SonarSource/ci-common-scripts/blob/99e4f81a2f98cdf8957598dcbfbdc339612fc539/src/burgr-notify-promotion#L8), but it is [no longer called from `cirrus_promote_maven`](https://github.com/SonarSource/ci-common-scripts/commit/3adbdd7b13111206846df463ba90ba1388783581#diff-efa0b28ec158d1639d284d06d6dbc5bd9df0d2273316bbbdf0fd6371cfbed104L57).
 - The changes are similar to the ones in this sample PR: SonarSource/sonar-dummy-oss#200