### PR TITLE
SSLR-400 [NFC] Avoid always getting action for rule in SyntaxTreeCreator::visitNonTerminal

### DIFF
--- a/sslr-core/src/main/java/com/sonar/sslr/impl/typed/SyntaxTreeCreator.java
+++ b/sslr-core/src/main/java/com/sonar/sslr/impl/typed/SyntaxTreeCreator.java
@@ -72,7 +72,6 @@ public class SyntaxTreeCreator<T> {
   private Object visitNonTerminal(ParseNode node) {
     MutableParsingRule rule = (MutableParsingRule) node.getMatcher();
     GrammarRuleKey ruleKey = rule.getRuleKey();
-    Method method = mapping.actionForRuleKey(ruleKey);
 
     Object result;
 
@@ -100,6 +99,7 @@ public class SyntaxTreeCreator<T> {
       for (ParseNode child : node.getChildren()) {
         convertedChildren.add(visit(child));
       }
+      Method method = mapping.actionForRuleKey(ruleKey);
       if (mapping.isOneOrMoreRule(ruleKey)) {
         result = convertedChildren;
       } else if (mapping.isZeroOrMoreRule(ruleKey)) {


### PR DESCRIPTION
Hi,

I've been profiling a medium size PHP project and in flamegraphs I often see in `SyntaxTreeCreator::visitNonTerminal` that there is a portion spent on `HashMap.get()`

Always getting the action for a rule key seems to be one of the less common branches (judging from the flamegraphs and the code), so I think this is an easy - admittedly very tiny - micro-optimization.

<img width="933" alt="image" src="https://github.com/user-attachments/assets/d1b67a4d-b708-490b-a8d0-b786c03305af">

Don't mind the 0.00% in the screenshot - it's such a deep stack that the actual calls often are not even sampled. But they are executed and account for ~1% of the samples in my profilings. Zooming in on the first line of `SyntaxTreeCreator::visitNonTerminal` and looking for `actionForRuleKey` shows that they make up ~11% of the samples in that stack.

<img width="1678" alt="image" src="https://github.com/user-attachments/assets/f5507b58-2522-4ec9-aab6-4d424ccd644d">

The worst thing that happens would be cleaner flamegraphs.

Let me know what you think.
Cheers,
Christoph