### PR TITLE
Autoclose issues created by Jira integration

### DIFF
--- a/.github/workflows/PullRequestClosed.yml
+++ b/.github/workflows/PullRequestClosed.yml
@@ -14,7 +14,6 @@ jobs:
     # For external PR, ticket should be moved manually
     if: |
         github.event.pull_request.head.repo.full_name == github.repository
-        && github.event.pull_request.merged
     steps:
       - id: secrets
         uses: SonarSource/vault-action-wrapper@v3


### PR DESCRIPTION
This will enable the automation to close issues that it created, to keep things more cleaned up.

Manually created issues will not be affected.
