### PR TITLE
Revert "BUILD-7557 Run github actions on sonar-runner instead of ubuntu-latest"

### DIFF
--- a/.github/workflows/PullRequestClosed.yml
+++ b/.github/workflows/PullRequestClosed.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   PullRequestMerged_job:
     name: Pull Request Merged
-    runs-on: sonar-runner
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
       pull-requests: read

--- a/.github/workflows/RequestReview.yml
+++ b/.github/workflows/RequestReview.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   RequestReview_job:
     name: Request review
-    runs-on: sonar-runner
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
     # For external PR, ticket should be moved manually

--- a/.github/workflows/SubmitReview.yml
+++ b/.github/workflows/SubmitReview.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   SubmitReview_job:
     name: Submit Review
-    runs-on: sonar-runner
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
       pull-requests: read

--- a/.github/workflows/mark-prs-stale.yml
+++ b/.github/workflows/mark-prs-stale.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   stale:
-    runs-on: sonar-runner
+    runs-on: ubuntu-latest
     permissions:
       issues: write
       pull-requests: write


### PR DESCRIPTION
This reverts commit 363561c8fa46792f37e6125998ed8282421533a9.

We should still use GitHub runners for public repositories.