### PR TITLE
Pin GitHub actions to a full length commit SHA: update version

### DIFF
--- a/.github/workflows/PullRequestClosed.yml
+++ b/.github/workflows/PullRequestClosed.yml
@@ -21,7 +21,7 @@ jobs:
           secrets: |
             development/kv/data/jira user | JIRA_USER;
             development/kv/data/jira token | JIRA_TOKEN;
-      - uses: sonarsource/gh-action-lt-backlog/PullRequestClosed@ce77d2888d0e002bd644a7266feae9dddd141a94 # v2
+      - uses: sonarsource/gh-action-lt-backlog/PullRequestClosed@c686e352b369c4237e859acf335bf205a3926ebf # v2
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           jira-user:  ${{ fromJSON(steps.secrets.outputs.vault).JIRA_USER }}

--- a/.github/workflows/RequestReview.yml
+++ b/.github/workflows/RequestReview.yml
@@ -21,7 +21,7 @@ jobs:
             development/github/token/{REPO_OWNER_NAME_DASH}-jira token | GITHUB_TOKEN;
             development/kv/data/jira user | JIRA_USER;
             development/kv/data/jira token | JIRA_TOKEN;
-      - uses: sonarsource/gh-action-lt-backlog/RequestReview@ce77d2888d0e002bd644a7266feae9dddd141a94 # v2
+      - uses: sonarsource/gh-action-lt-backlog/RequestReview@c686e352b369c4237e859acf335bf205a3926ebf # v2
         with:
           github-token: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
           jira-user:    ${{ fromJSON(steps.secrets.outputs.vault).JIRA_USER }}

--- a/.github/workflows/SubmitReview.yml
+++ b/.github/workflows/SubmitReview.yml
@@ -23,7 +23,7 @@ jobs:
           secrets: |
             development/kv/data/jira user | JIRA_USER;
             development/kv/data/jira token | JIRA_TOKEN;
-      - uses: sonarsource/gh-action-lt-backlog/SubmitReview@ce77d2888d0e002bd644a7266feae9dddd141a94 # v2
+      - uses: sonarsource/gh-action-lt-backlog/SubmitReview@c686e352b369c4237e859acf335bf205a3926ebf # v2
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           jira-user: ${{ fromJSON(steps.secrets.outputs.vault).JIRA_USER }}


### PR DESCRIPTION
Follow recommended practice:
* https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
* https://xtranet-sonarsource.atlassian.net/wiki/spaces/IS/pages/3990552676/GitHub+Action+Secure+Configuration+Policy#3.-Ensure-third-party-actions-are-pinned-to-a-full-length-commit-SHA
