### PR TITLE
Migrate release workflow to gh-action_release v7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,21 @@
 name: sonar-release
-# This workflow is triggered when publishing a new github release
+# This workflow is triggered manually with the full release version.
 on:
-  release:
-    types:
-      - published
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Full version including build number, e.g. 1.25.1.3886
+        required: true
+        type: string
 
 jobs:
   release:
     permissions:
       id-token: write
       contents: write
-    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v6
+    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v7
     with:
+      version: ${{ inputs.version }}
       publishToBinaries: false
       mavenCentralSync: true
       slackChannel: squad-cfamily-notifications


### PR DESCRIPTION
v6 is deprecated and replaced by v7 for immutable releases and tags.

Switch release triggering from the deprecated release:published event to manual workflow_dispatch with a required full version input, and pass that version to the reusable workflow.

Rationale: Release and Tag Immutability guidance

https://xtranet-sonarsource.atlassian.net/wiki/spaces/Platform/pages/5141594243/Release+and+Tag+Immutability+-+GitHub#gh-action_release-%E2%80%94-migrate-to-v7
