### PR TITLE
Add check-sca workflow for validation

### DIFF
--- a/.github/workflows/check-sca.yml
+++ b/.github/workflows/check-sca.yml
@@ -1,0 +1,16 @@
+name: Required SCA Check
+on:
+  pull_request:
+  merge_group:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  verify-sca:
+    runs-on: github-ubuntu-latest-s  # Public repo with auth actions
+    name: Verify SCA
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: SonarSource/ci-github-actions/check-sca@v1

--- a/.github/workflows/check-sca.yml
+++ b/.github/workflows/check-sca.yml
@@ -14,3 +14,5 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: SonarSource/ci-github-actions/check-sca@v1
+        with:
+          project-key: org.sonarsource.sslr:sslr


### PR DESCRIPTION
## Summary
- add a dedicated `Required SCA Check` workflow on `pull_request` and `merge_group`
- use `SonarSource/ci-github-actions/check-sca@v1`
- intentionally do not set `project-key` to validate current key auto-discovery behavior in this repo

## Why
The repo already runs Sonar analysis from the build workflow, but DX/SCA status remains red. This draft PR is meant to validate whether `check-sca` is failing because discovered project keys do not match the effective analysis key.

## Follow-up
If the run confirms key mismatch, we can pin `project-key: org.sonarsource.sslr:sslr` in this workflow in a follow-up commit.