### PR TITLE
CLP-129 Restore PR cleanup job and spacing

### DIFF
--- a/.github/workflows/PullRequestClosed.yml
+++ b/.github/workflows/PullRequestClosed.yml
@@ -24,5 +24,12 @@ jobs:
       - uses: sonarsource/gh-action-lt-backlog/PullRequestClosed@v2
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
-          jira-user:  ${{ fromJSON(steps.secrets.outputs.vault).JIRA_USER }}
-          jira-token: ${{ fromJSON(steps.secrets.outputs.vault).JIRA_TOKEN }}
+          jira-user:    ${{ fromJSON(steps.secrets.outputs.vault).JIRA_USER }}
+          jira-token:   ${{ fromJSON(steps.secrets.outputs.vault).JIRA_TOKEN }}
+
+  PR_Build_Cleanup:
+    runs-on: sonar-xs
+    permissions:
+      actions: write
+    steps:
+      - uses: SonarSource/ci-github-actions/pr_cleanup@v1


### PR DESCRIPTION
## Summary
This is a follow-up to the CLP-129 Jira automation batch.

The original CLP-129 PR for this repository was already merged before Pavel's feedback on `sonar-vb` was propagated across the whole batch.

This PR keeps the repository aligned with the other CLP-129 repos by:
- restoring the intentional spacing in `.github/workflows/PullRequestClosed.yml`
- restoring the `PR_Build_Cleanup` job in `.github/workflows/PullRequestClosed.yml`