### PR TITLE
SSLR-415 Add the automated release workflow

### DIFF
--- a/.github/workflows/automated_release.yml
+++ b/.github/workflows/automated_release.yml
@@ -1,0 +1,60 @@
+name: Automated Release
+on:
+  workflow_dispatch:
+    inputs:
+      short-description:
+        description: "Short description for the REL ticket"
+        required: true
+        type: string
+      branch:
+        description: "Branch from which to do the release"
+        required: true
+        default: "master"
+        type: string
+      new-version:
+        description: "New version to release (without -SNAPSHOT; if left empty, the current minor version will be auto-incremented)"
+        required: false
+        type: string
+      verbose:
+        description: "Enable verbose logging"
+        type: boolean
+        default: false
+      dry-run:
+        description: "Test mode: uses Jira sandbox and creates draft GitHub release"
+        type: boolean
+        default: true
+      bump-version:
+        description: "Create PR to bump the next iteration version"
+        type: boolean
+        default: true
+
+jobs:
+  release:
+    name: Release
+    uses: SonarSource/release-github-actions/.github/workflows/automated-release.yml@v1
+    permissions:
+      statuses: write
+      id-token: write
+      contents: write
+      actions: write
+      pull-requests: write
+    with:
+      project-name: "sslr"
+      plugin-name: "sslr"
+      jira-project-key: "SSLR"
+      runner-environment: "sonar-xs-public"
+      rule-props-changed: false
+      short-description: ${{ github.event.inputs.short-description }}
+      new-version: ${{ github.event.inputs.new-version }}
+      sqc-integration: false
+      sqs-integration: false
+      branch: ${{ github.event.inputs.branch }}
+      pm-email: "jean.jimbo@sonarsource.com"
+      slack-channel: "squad-corelang-releases"
+      verbose: ${{ github.event.inputs.verbose == 'true' }}
+      use-jira-sandbox: ${{ github.event.inputs.dry-run == 'true' }}
+      is-draft-release: ${{ github.event.inputs.dry-run == 'true' }}
+      issue-categories: "Feature,False Positive,False Negative,Bug,Security,Maintenance"
+      bump-version: ${{ github.event.inputs.bump-version == 'true' }}
+      bump-version-normalize: true
+      bump-version-tool: maven

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,10 @@ on:
         description: Full version including build number, e.g. 1.25.1.3886
         required: true
         type: string
+      dryRun:
+        type: boolean
+        description: Flag to enable the dry-run execution
+        default: false
 
 jobs:
   release:
@@ -16,6 +20,7 @@ jobs:
     uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v7
     with:
       version: ${{ inputs.version }}
+      dryRun: ${{ inputs.dryRun == true }}
       publishToBinaries: false
       mavenCentralSync: true
       slackChannel: squad-corelang-releases


### PR DESCRIPTION
----
## Summary by Gitar

- **CI/CD:**
  - Added `.github/workflows/automated_release.yml` to support automated releases via `SonarSource/release-github-actions`.
  - Configured project-specific release settings including Jira integration, Slack notifications, and Maven version bumping.

<sub>This will update automatically on new commits.</sub>