### PR TITLE
SSLR-417 Deactivate notifications in automated release dry runs and remove specific runner environment

### DIFF
--- a/.github/workflows/automated_release.yml
+++ b/.github/workflows/automated_release.yml
@@ -42,7 +42,6 @@ jobs:
       project-name: "sslr"
       plugin-name: "sslr"
       jira-project-key: "SSLR"
-      runner-environment: "sonar-xs-public"
       rule-props-changed: false
       short-description: ${{ github.event.inputs.short-description }}
       new-version: ${{ github.event.inputs.new-version }}
@@ -50,7 +49,8 @@ jobs:
       sqs-integration: false
       branch: ${{ github.event.inputs.branch }}
       pm-email: "jean.jimbo@sonarsource.com"
-      slack-channel: "squad-corelang-releases"
+      slack-channel: ${{ github.event.inputs.dry-run != 'true' && 'squad-corelang-releases' || '' }}
+      freeze-branch-slack-notification: ${{ github.event.inputs.dry-run != 'true' }}
       verbose: ${{ github.event.inputs.verbose == 'true' }}
       use-jira-sandbox: ${{ github.event.inputs.dry-run == 'true' }}
       is-draft-release: ${{ github.event.inputs.dry-run == 'true' }}


### PR DESCRIPTION
----
## Summary by Gitar

- **Workflow configuration:**
  - Removed `runner-environment` from the automated release workflow job parameters.
  - Updated `slack-channel` and added `freeze-branch-slack-notification` to conditional logic based on `dry-run` input.

<sub>This will update automatically on new commits.</sub>